### PR TITLE
JS Bugfixes and Correctness

### DIFF
--- a/brave/forums/model.py
+++ b/brave/forums/model.py
@@ -92,7 +92,7 @@ class Forum(Document):
     name = StringField(db_field='n')
     summary = StringField(db_field='u')
     
-    # The tag needed to read (view) or wrie (post to) this forum.
+    # The tag needed to read (view) or write (post to) this forum.
     read = StringField(db_field='r')
     write = StringField(db_field='w')
     moderate = StringField(db_field='m')

--- a/brave/forums/template/thread.html
+++ b/brave/forums/template/thread.html
@@ -36,16 +36,19 @@
             
             $('#comment-submit').on('click', function(){
                 var self = $(this);
-                self.addClass('disabled').attr('disabled', true);
+                self.addClass('disabled').prop('disabled', true);
                 
                 $.post($('#comment-panel').attr('action'), {message: $('#comment-message').val()}, function(result){
-                    if ( ! result.success ) {
+                    if ( ! result.success )
+                    {
+                        alert(result.message);
+                        self.removeClass('disabled').prop('disabled', false);
                         return;
                     }
                     
-                    // We would have had our own message pushed to us.  :3
+                    // We would hopefully have had our own message pushed to us.  :3
                     $('#comment-message').val('');
-                    self.removeClass('disabled').attr('disabled', false);
+                    self.removeClass('disabled').prop('disabled', false);
                 });
                 
                 return false;

--- a/brave/forums/template/thread.html
+++ b/brave/forums/template/thread.html
@@ -39,8 +39,7 @@
                 self.addClass('disabled').prop('disabled', true);
                 
                 $.post($('#comment-panel').attr('action'), {message: $('#comment-message').val()}, function(result){
-                    if ( ! result.success )
-                    {
+                    if ( ! result.success ) {
                         alert(result.message);
                         self.removeClass('disabled').prop('disabled', false);
                         return;


### PR DESCRIPTION
Bugfix for submitting an empty message and having the submit button permnantly disabled
Change attr('disabled') to prop('disabled') in the jQuery Code
Docs Typo Fix
