### PR TITLE
Handle 0-threads case in is_forum_read (fixes #40)

### DIFF
--- a/brave/forums/auth/model.py
+++ b/brave/forums/auth/model.py
@@ -118,6 +118,8 @@ class Character(Document):
                 str(thread.id) in d and d[str(thread.id)] > thread.modified)
 
     def is_forum_read(self, forum):
+        if not forum.threads:
+            return True
         if str(forum.id) not in self.read:
             return False
         d = self.read[str(forum.id)]


### PR DESCRIPTION
This fixes both the problem that empty forums show as unread, and the
error after marking an empty forum as read.
