### PR TITLE
Spoiler bbcode tweaks (fixes #45)

### DIFF
--- a/brave/forums/util/tags.py
+++ b/brave/forums/util/tags.py
@@ -17,13 +17,11 @@ class SemanticTagParser(object):
             'Alliance'  : self.format_evewho,
             'DebugTag' : self.format_logging
         }
-        self.block_available_tags = {
-            'Spoilers' : self.format_spoilers,
-        }
         for tag, parser in self.standalone_available_tags.iteritems():
             self.parser.add_formatter(tag, parser, standalone = True)
-        for tag, parser in self.block_available_tags.iteritems():
-            self.parser.add_formatter(tag, parser, standalone = False)
+        self.parser.add_formatter('Spoiler', self.format_spoilers,
+                                  standalone = False,
+                                  strip = True)
 
     def format(self, text):
         return self.parser.format(text)


### PR DESCRIPTION
- rename [spoilers] to [spoiler] since that seems to be more standard.
  Hopefully no one is depending on this too much yet.
- strip leading & trailing whitespace inside spoiler tags. I'm not sure
  whether this is standard, but I definitely think it is better.
