### PR TITLE
Allow mid-word wrapping in comments (fixes #49)

### DIFF
--- a/brave/forums/public/css/styles.css
+++ b/brave/forums/public/css/styles.css
@@ -156,6 +156,10 @@ ul.nav-pills i.fa {
     z-index: 1;
 }
 
+.comment .panel-body {
+    word-wrap: break-word;
+}
+
 .spoiler-container {
     padding: 5px;
     border: 1px solid;


### PR DESCRIPTION
Firefox does this by default, but Chrome doesn't.
