### PR TITLE
Renamed "Start Discussion" to "Post Discussion"

### DIFF
--- a/brave/forums/template/forum.html
+++ b/brave/forums/template/forum.html
@@ -136,7 +136,7 @@
                         </a>
                     </li>
                 </ul>
-                <button id="comment-submit" type="button" class="btn navbar-btn btn-primary navbar-right"><i class="fa fa-fw fa-check"></i> Start Discussion</button>
+                <button id="comment-submit" type="button" class="btn navbar-btn btn-primary navbar-right"><i class="fa fa-fw fa-check"></i> Post Discussion</button>
             </nav>
 
             <div class="tab-content">

--- a/brave/forums/template/syntax.html
+++ b/brave/forums/template/syntax.html
@@ -188,7 +188,7 @@
                     <tbody>
                         <tr>
                             <td>
-                                <code>[System=Barleuget]</code>
+                                <code>[System=Barleguet]</code>
                             </td>
                             <td>
                                 <a href="http://evemaps.dotlan.net/system/Barleguet" target="dotlan">Barleguet</a>


### PR DESCRIPTION
Having two buttons labelled start when creating a new post is confusing.
