### PR TITLE
Fix hidden style guide (fixes #69)

### DIFF
--- a/brave/forums/public/css/styles.css
+++ b/brave/forums/public/css/styles.css
@@ -260,7 +260,7 @@ div[id^="comment-"] {
 	padding: 0;
 }
 
-.style-panel .content{
+.style-panel .content, #style-panel .content {
 	padding: 0;
 	display: block !important;
 }

--- a/brave/forums/template/forum.html
+++ b/brave/forums/template/forum.html
@@ -131,7 +131,7 @@
                     <li class="active"><a href="#comment-panel" data-toggle="tab"><i class="fa fa-pencil-square"></i> Write</a></li>
                     <li><a id="trigger-preview" href="#preview-panel" data-toggle="tab"><i class="fa fa-check-square"></i> Preview</a></li>
                     <li>
-                        <a id="trigger-preview" href="#style-panel" data-toggle="tab">
+                        <a id="trigger-style" href="#style-panel" data-toggle="tab">
                             <i class="fa fa-font"></i> Style Guide
                         </a>
                     </li>


### PR DESCRIPTION
I don't really like having similar-but-slightly-different UI like this,
but the start discussion UI is due for changes anyway, so I didn't
bother to bring it in line with the other commenting UI here.

Also fix a repeated element ID while I was looking.
