### PR TITLE
Non-push-reliant commenting

### DIFF
--- a/brave/forums/component/thread/controller.py
+++ b/brave/forums/component/thread/controller.py
@@ -46,9 +46,9 @@ class ThreadIndex(HTTPMethod):
         if not message or not message.strip():
             return 'json:', dict(success=False, message="Empty message.")
         
-        self.thread.add_comment(user._current_obj(), message)
+        new_comment = self.thread.add_comment(user._current_obj(), message)
         
-        return 'json:', dict(success=True)
+        return 'json:', dict(success=True, comment=new_comment.id)
 
 
 

--- a/brave/forums/public/js/live.js
+++ b/brave/forums/public/js/live.js
@@ -292,6 +292,8 @@ Thread.prototype.commented = function(e, identifier) {
     if ( $('#' + identifier).length ) return;
     
     $.get(window.location.pathname + '/' + identifier + '.html', function(result) {
+        // This is really where de-dupe is most critical.
+        if ( $('#' + identifier).length ) return;
         $(result).insertAfter('.comment:last');
         $('time.relative').timeago();
     });

--- a/brave/forums/template/thread.html
+++ b/brave/forums/template/thread.html
@@ -172,9 +172,11 @@ BASE = "/{0}/{1}".format(forum.short, thread.id)
                         alert(result.message);
                         self.removeClass('disabled').prop('disabled', false);
                         return;
+                    } else {
+                        // Why use a push request when we're already getting an AJAX response?
+                        thread.commented(null, result.comment);
                     }
                     
-                    // We would hopefully have had our own message pushed to us.  :3
                     editor.find('.message').val('');
                     editor.find('.preview-panel .content').empty();
                     self.removeClass('disabled').prop('disabled', false);


### PR DESCRIPTION
There's no reason to require a (sometimes unreliable) push notification to add a new comment when there's already the original AJAX call sending back a response.
