### PR TITLE
kill fa-spin for perf (fixes #63)

### DIFF
--- a/brave/forums/public/css/styles.css
+++ b/brave/forums/public/css/styles.css
@@ -324,10 +324,10 @@ blockquote {
 .nav.alice a[data-theme] i { margin-right: 3px; }
 
 .infini { text-align: center; margin-bottom: 20px; }
-.infini i.fa-spin { visibility: hidden; }
+.infini i.fa-spinner { visibility: hidden; }
 .infini i.fa-times { display: none; }
-.infini.active i.fa-spin { visibility: visible; }
-.infini.disabled i.fa-spin { display: none; }
+.infini.active i.fa-spinner { visibility: visible; }
+.infini.disabled i.fa-spinner { display: none; }
 .infini.disabled i.fa-times { display: inline; }
 
 .comment-content img { display: block; max-width: 100%; }

--- a/brave/forums/template/forum.html
+++ b/brave/forums/template/forum.html
@@ -127,7 +127,7 @@
                                 <textarea id="comment-message" class="form-control message" placeholder="Leave a comment." rows="5"></textarea>
                             </form>
                             <div class="tab-pane fade preview-panel" id="preview-panel">
-                                <div class="spinner"><i class="fa fa-5x fa-cog fa-spin"></i></div>
+                                <div class="spinner"><i class="fa fa-5x fa-cog"></i></div>
                                 <div class="content"></div>
                             </div>
                             <div class="tab-pane fade style-panel" id="style-panel" style="padding: 0;">
@@ -213,6 +213,6 @@ ${threads(forum, forum.threads.filter(flag__sticky=True))}
 ${threads(forum, forum.threads.filter(flag__sticky=False), page)}
 
 <div class="infini">
-    <i class="fa fa-4x fa-spin fa-spinner"></i>
+    <i class="fa fa-4x fa-spinner"></i>
     <i class="fa fa-4x fa-times text-muted"></i>
 </div>

--- a/brave/forums/template/thread.html
+++ b/brave/forums/template/thread.html
@@ -215,12 +215,6 @@ BASE = "/{0}/{1}".format(forum.short, thread.id)
         <li class="hidden disabled"><a href="#comment-panel" id="thread-locked" class="disabled"><i class="fa fa-lock fa-lg"></i> Thread Locked</a></li>
         % endif
         % endif
-        <li class="pull-right connection-state"><a href="#" id="toggle-live">
-            <i class="fa fa-lg fa-refresh fa-spin live hidden"></i>
-            <i class="fa fa-lg fa-cog fa-spin connecting hidden"></i>
-            <i class="fa fa-lg fa-minus disconnected"></i>
-            Live
-        </a></li>
     % elif side == 'right':
         % if web.user and (web.user.admin or forum.moderate in web.user.tags):
         <li${' class="active"' if thread.flag.locked else ''}><a href="${BASE}/lock" class="sjax"><i class="fa fa-lock fa-fw fa-lg"></i></a></li>
@@ -372,7 +366,7 @@ ${render_comment(comment, None if i else thread.title)}
                     <textarea class="message form-control" placeholder="Leave a comment." rows="5"></textarea>
                 </form>
                 <div class="preview-panel tab-pane fade">
-                    <div class="spinner"><i class="fa fa-5x fa-cog fa-spin"></i></div>
+                    <div class="spinner"><i class="fa fa-5x fa-cog"></i></div>
                     <div class="content comment-content"></div>
                 </div>
                 <div class="style-panel tab-pane fade">


### PR DESCRIPTION
Font Awesome, we need to talk. In 1994, people were [rendering 320p 3d graphics on Amigas in real-time](http://www.demoscene.tv/page.php?id=172&lang=uk&vsmaction=view_prod&id_prod=4541). Two decades later, you need half a core to animate your 32x32 spinning icon? Fuck off, buddy, just fuck off.
